### PR TITLE
Added logind lock state checking to fix the issue with pgrep based process checking

### DIFF
--- a/src/core/manager/actions.rs
+++ b/src/core/manager/actions.rs
@@ -1,267 +1,301 @@
-use std::time::Duration;
-use eyre::Result;
-use tokio::process::Command;
-use std::process::Stdio;
-use crate::config::model::{IdleActionBlock, IdleAction};
+use crate::config::model::{IdleAction, IdleActionBlock};
 use crate::log::log_message;
+use eyre::Result;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+
+/// Check if the session is locked via systemd logind
+/// Returns Some(true) if locked, Some(false) if unlocked, None if unable to query
+pub async fn is_session_locked_via_logind() -> Option<bool> {
+  match Command::new("busctl")
+    .arg("get-property")
+    .arg("--system")
+    .arg("--")
+    .arg("org.freedesktop.login1")
+    .arg("/org/freedesktop/login1/session/auto")
+    .arg("org.freedesktop.login1.Session")
+    .arg("LockedHint")
+    .output()
+    .await
+  {
+    Ok(output) => {
+      let output_str = String::from_utf8_lossy(&output.stdout);
+      let is_locked = output_str.trim() == "b true";
+      log_message(&format!(
+        "logind LockedHint check: {} (raw: {})",
+        is_locked,
+        output_str.trim()
+      ));
+      Some(is_locked)
+    }
+    Err(e) => {
+      log_message(&format!("Failed to check logind LockedHint: {}", e));
+      None
+    }
+  }
+}
 
 #[derive(Debug, Clone)]
 pub enum ActionRequest {
-    RunCommand(String),
-    Skip(String),
+  RunCommand(String),
+  Skip(String),
 }
 
 /// Information about a spawned process
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
-    pub pid: u32,
-    pub pgid: u32,
-    pub command: String,
-    pub expected_process_name: Option<String>,
+  pub pid: u32,
+  pub pgid: u32,
+  pub command: String,
+  pub expected_process_name: Option<String>,
 }
 
 /// Prepare action for execution
 pub async fn prepare_action(action: &IdleActionBlock) -> Vec<ActionRequest> {
-    let cmd = action.command.clone();
-    match action.kind {
-        IdleAction::Suspend => {
-            if !cmd.trim().is_empty() {
-                vec![ActionRequest::RunCommand(cmd)]
-            } else {
-                vec![]
-            }
-        }
-        IdleAction::LockScreen => {
-            let probe_cmd = if let Some(ref lock_cmd) = action.lock_command {
-                lock_cmd
-            } else {
-                &action.command
-            };
-            
-            if is_process_running(probe_cmd).await {
-                log_message("Lockscreen already running, skipping action.");
-                vec![ActionRequest::Skip(probe_cmd.to_string())]
-            } else {
-                vec![ActionRequest::RunCommand(action.command.clone())]
-            }
-        }
-        _ => {
-            if cmd.trim().is_empty() {
-                vec![]
-            } else {
-                vec![ActionRequest::RunCommand(cmd)]
-            }
-        }
+  let cmd = action.command.clone();
+  match action.kind {
+    IdleAction::Suspend => {
+      if !cmd.trim().is_empty() {
+        vec![ActionRequest::RunCommand(cmd)]
+      } else {
+        vec![]
+      }
     }
+    IdleAction::LockScreen => {
+      // Check lock state using systemd logind DBus
+      let logind_result = is_session_locked_via_logind().await;
+
+      let is_locked = match logind_result {
+        Some(locked) => {
+          // logind query succeeded - use its result as authoritative
+          log_message(&format!("Using logind detection: locked={}", locked));
+          locked
+        }
+        None => {
+          // logind query failed - fall back to process check
+          // NOTE: This is flawed for nested commands (e.g., quickshell, shell scripts) but it is kept as a fallback for systems without working logind
+          log_message("logind unavailable, falling back to process check (may be inaccurate for nested commands)");
+
+          let is_locked_process = if let Some(ref lock_cmd) = action.lock_command {
+            is_process_running(lock_cmd).await
+          } else {
+            is_process_running(&action.command).await
+          };
+
+          log_message(&format!("Process check result: locked={}", is_locked_process));
+          is_locked_process
+        }
+      };
+
+      if is_locked {
+        log_message("Lockscreen already active, skipping action.");
+        let probe_cmd = action.lock_command.as_ref().unwrap_or(&action.command);
+        vec![ActionRequest::Skip(probe_cmd.to_string())]
+      } else {
+        vec![ActionRequest::RunCommand(action.command.clone())]
+      }
+    }
+    _ => {
+      if cmd.trim().is_empty() {
+        vec![]
+      } else {
+        vec![ActionRequest::RunCommand(cmd)]
+      }
+    }
+  }
 }
 
 /// Run a shell command silently (log to /tmp/stasis.log)
 pub async fn run_command_silent(cmd: &str) -> Result<()> {
-    let log_file = "/tmp/stasis.log";
-    let fut = async {
-        let mut child = Command::new("sh")
-            .arg("-c")
-            .arg(format!("{cmd} >> {log_file} 2>&1"))
-            .envs(std::env::vars())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?;
-        let status = child.wait().await?;
-        if !status.success() {
-            eyre::bail!("Command '{}' exited with status {:?}", cmd, status.code());
-        }
-        Ok::<(), eyre::Report>(())
-    };
-    tokio::time::timeout(Duration::from_secs(30), fut).await??;
-    Ok(())
+  let log_file = "/tmp/stasis.log";
+  let fut = async {
+    let mut child = Command::new("sh")
+      .arg("-c")
+      .arg(format!("{cmd} >> {log_file} 2>&1"))
+      .envs(std::env::vars())
+      .stdin(Stdio::null())
+      .stdout(Stdio::null())
+      .stderr(Stdio::null())
+      .spawn()?;
+    let status = child.wait().await?;
+    if !status.success() {
+      eyre::bail!("Command '{}' exited with status {:?}", cmd, status.code());
+    }
+    Ok::<(), eyre::Report>(())
+  };
+  tokio::time::timeout(Duration::from_secs(30), fut).await??;
+  Ok(())
 }
 
 /// Run a command detached and return comprehensive process info
 pub async fn run_command_detached(command: &str) -> Result<ProcessInfo, Box<dyn std::error::Error>> {
-    if command.trim().is_empty() {
-        return Err("Empty command".into());
-    }
+  if command.trim().is_empty() {
+    return Err("Empty command".into());
+  }
 
-    // Create a new process group by using setsid
-    let child = Command::new("sh")
-        .arg("-c")
-        .arg(command)
-        .envs(std::env::vars())
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .process_group(0) // Create new process group
-        .spawn()?;
+  // Create a new process group by using setsid
+  let child = Command::new("sh")
+    .arg("-c")
+    .arg(command)
+    .envs(std::env::vars())
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .process_group(0) // Create new process group
+    .spawn()?;
 
-    let pid = child.id().ok_or("Failed to get child PID")?;
-    
-    // Get the process group ID (usually same as PID for process group leader)
-    let pgid = get_pgid(pid).await.unwrap_or(pid);
-    
-    // Extract expected process name from command for later verification
-    let expected_name = extract_expected_process_name(command);
-    
-    log_message(&format!(
-        "Spawned process: PID={}, PGID={}, expected_name={:?}",
-        pid, pgid, expected_name
-    ));
+  let pid = child.id().ok_or("Failed to get child PID")?;
 
-    Ok(ProcessInfo {
-        pid,
-        pgid,
-        command: command.to_string(),
-        expected_process_name: expected_name,
-    })
+  // Get the process group ID (usually same as PID for process group leader)
+  let pgid = get_pgid(pid).await.unwrap_or(pid);
+
+  // Extract expected process name from command for later verification
+  let expected_name = extract_expected_process_name(command);
+
+  log_message(&format!(
+    "Spawned process: PID={}, PGID={}, expected_name={:?}",
+    pid, pgid, expected_name
+  ));
+
+  Ok(ProcessInfo {
+    pid,
+    pgid,
+    command: command.to_string(),
+    expected_process_name: expected_name,
+  })
 }
 
 /// Extract the expected process name from a command
 fn extract_expected_process_name(command: &str) -> Option<String> {
-    let first_word = command.split_whitespace().next()?;
-    
-    // Get just the binary name (last component of the path)
-    let binary_name = std::path::Path::new(first_word)
-        .file_name()
-        .and_then(|s| s.to_str())?
-        .to_string();
-    
-    Some(binary_name)
+  let first_word = command.split_whitespace().next()?;
+
+  // Get just the binary name (last component of the path)
+  let binary_name = std::path::Path::new(first_word)
+    .file_name()
+    .and_then(|s| s.to_str())?
+    .to_string();
+
+  Some(binary_name)
 }
 
 /// Get process group ID for a PID
 async fn get_pgid(pid: u32) -> Option<u32> {
-    let stat_path = format!("/proc/{}/stat", pid);
-    let contents = tokio::fs::read_to_string(&stat_path).await.ok()?;
-    
-    // Parse /proc/[pid]/stat - PGID is the 5th field
-    let fields: Vec<&str> = contents.split_whitespace().collect();
-    if fields.len() > 4 {
-        fields[4].parse().ok()
-    } else {
-        None
-    }
+  let stat_path = format!("/proc/{}/stat", pid);
+  let contents = tokio::fs::read_to_string(&stat_path).await.ok()?;
+
+  // Parse /proc/[pid]/stat - PGID is the 5th field
+  let fields: Vec<&str> = contents.split_whitespace().collect();
+  if fields.len() > 4 { fields[4].parse().ok() } else { None }
 }
 
 /// Check if a process or its descendants are still running
 pub async fn is_process_active(info: &ProcessInfo) -> bool {
-    // Strategy 1: Check if original PID still exists
-    if std::path::Path::new(&format!("/proc/{}", info.pid)).exists() {
-        return true;
+  // Strategy 1: Check if original PID still exists
+  if std::path::Path::new(&format!("/proc/{}", info.pid)).exists() {
+    return true;
+  }
+
+  // Strategy 2: Check process group for any surviving members
+  if let Some(pids) = get_process_group_members(info.pgid).await {
+    if !pids.is_empty() {
+      log_message(&format!(
+        "Original PID {} dead, but process group {} has {} member(s)",
+        info.pid,
+        info.pgid,
+        pids.len()
+      ));
+      return true;
     }
-    
-    // Strategy 2: Check process group for any surviving members
-    if let Some(pids) = get_process_group_members(info.pgid).await {
-        if !pids.is_empty() {
-            log_message(&format!(
-                "Original PID {} dead, but process group {} has {} member(s)",
-                info.pid, info.pgid, pids.len()
-            ));
-            return true;
-        }
+  }
+
+  // Strategy 3: If we know the expected process name, search for it
+  if let Some(ref name) = info.expected_process_name {
+    if is_process_running(name).await {
+      log_message(&format!("Process group empty, but found '{}' by name", name));
+      return true;
     }
-    
-    // Strategy 3: If we know the expected process name, search for it
-    if let Some(ref name) = info.expected_process_name {
-        if is_process_running(name).await {
-            log_message(&format!(
-                "Process group empty, but found '{}' by name",
-                name
-            ));
-            return true;
-        }
-    }
-    
-    false
+  }
+
+  false
 }
 
 /// Get all PIDs in a process group
 async fn get_process_group_members(pgid: u32) -> Option<Vec<u32>> {
-    let output = Command::new("ps")
-        .arg("-eo")
-        .arg("pid,pgid")
-        .output()
-        .await
-        .ok()?;
-    
-    if output.stdout.is_empty() {
-        return Some(Vec::new());
-    }
-    
-    let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .skip(1) // Skip header
-        .filter_map(|line| {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() >= 2 {
-                let pid: u32 = parts[0].parse().ok()?;
-                let proc_pgid: u32 = parts[1].parse().ok()?;
-                if proc_pgid == pgid {
-                    Some(pid)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-        .collect();
-    
-    Some(pids)
+  let output = Command::new("ps").arg("-eo").arg("pid,pgid").output().await.ok()?;
+
+  if output.stdout.is_empty() {
+    return Some(Vec::new());
+  }
+
+  let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+    .lines()
+    .skip(1) // Skip header
+    .filter_map(|line| {
+      let parts: Vec<&str> = line.split_whitespace().collect();
+      if parts.len() >= 2 {
+        let pid: u32 = parts[0].parse().ok()?;
+        let proc_pgid: u32 = parts[1].parse().ok()?;
+        if proc_pgid == pgid { Some(pid) } else { None }
+      } else {
+        None
+      }
+    })
+    .collect();
+
+  Some(pids)
 }
 
 /// Check if a process matching `cmd` is running (by name)
 pub async fn is_process_running(cmd: &str) -> bool {
-    if cmd.trim().is_empty() {
-        return false;
-    }
-    
-    // Extract the actual binary name from the command
-    let first_word = cmd.split_whitespace().next().unwrap_or("");
-    if first_word.is_empty() {
-        return false;
-    }
-    
-    // Get just the binary name (last component of the path)
-    let binary_name = std::path::Path::new(first_word)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or(first_word);
-    
-    match Command::new("pgrep").arg("-x").arg(binary_name).output().await {
-        Ok(output) => !output.stdout.is_empty(),
-        Err(_) => false,
-    }
+  if cmd.trim().is_empty() {
+    return false;
+  }
+
+  // Extract the actual binary name from the command
+  let first_word = cmd.split_whitespace().next().unwrap_or("");
+  if first_word.is_empty() {
+    return false;
+  }
+
+  // Get just the binary name (last component of the path)
+  let binary_name = std::path::Path::new(first_word)
+    .file_name()
+    .and_then(|s| s.to_str())
+    .unwrap_or(first_word);
+
+  match Command::new("pgrep").arg("-x").arg(binary_name).output().await {
+    Ok(output) => !output.stdout.is_empty(),
+    Err(_) => false,
+  }
 }
 
 /// Forcefully kill a process and its entire process group
 pub async fn kill_process_group(info: &ProcessInfo) -> Result<()> {
-    log_message(&format!(
-        "Killing process group {} (original PID: {})",
-        info.pgid, info.pid
-    ));
-    
-    // Kill entire process group
+  log_message(&format!(
+    "Killing process group {} (original PID: {})",
+    info.pgid, info.pid
+  ));
+
+  // Kill entire process group
+  let _ = Command::new("kill")
+    .arg("-TERM")
+    .arg(format!("-{}", info.pgid)) // Negative PGID kills the group
+    .output()
+    .await;
+
+  // Give processes time to terminate gracefully
+  tokio::time::sleep(Duration::from_millis(500)).await;
+
+  // Force kill if still alive
+  if is_process_active(info).await {
+    log_message(&format!("Process group {} still alive, sending SIGKILL", info.pgid));
     let _ = Command::new("kill")
-        .arg("-TERM")
-        .arg(format!("-{}", info.pgid)) // Negative PGID kills the group
-        .output()
-        .await;
-    
-    // Give processes time to terminate gracefully
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    
-    // Force kill if still alive
-    if is_process_active(info).await {
-        log_message(&format!(
-            "Process group {} still alive, sending SIGKILL",
-            info.pgid
-        ));
-        let _ = Command::new("kill")
-            .arg("-KILL")
-            .arg(format!("-{}", info.pgid))
-            .output()
-            .await;
-    }
-    
-    Ok(())
+      .arg("-KILL")
+      .arg(format!("-{}", info.pgid))
+      .output()
+      .await;
+  }
+
+  Ok(())
 }

--- a/src/core/manager/idle_loops.rs
+++ b/src/core/manager/idle_loops.rs
@@ -1,169 +1,189 @@
-use std::{sync::Arc, time::{Duration, Instant}};
+use std::{
+  sync::Arc,
+  time::{Duration, Instant},
+};
 use tokio::{
-    sync::Mutex, 
-    task::JoinHandle, 
-    time::{Instant as TokioInstant, sleep_until}
+  sync::Mutex,
+  task::JoinHandle,
+  time::{Instant as TokioInstant, sleep_until},
 };
 
 use crate::{
-    core::{manager::{Manager, actions::{is_process_running, is_process_active, run_command_detached}}}, 
-    log::log_message
+  core::manager::{
+    Manager,
+    actions::{is_process_active, is_process_running, is_session_locked_via_logind, run_command_detached},
+  },
+  log::log_message,
 };
 
 pub fn spawn_idle_task(manager: Arc<Mutex<Manager>>) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        loop {
-            // Grab both the next timeout and the notify handles
-            let (next_instant, notify, shutdown) = {
-                let mgr = manager.lock().await;
-                (
-                    mgr.next_action_instant(),
-                    mgr.state.notify.clone(),
-                    mgr.state.shutdown_flag.clone(),
-                )
-            };
+  tokio::spawn(async move {
+    loop {
+      // Grab both the next timeout and the notify handles
+      let (next_instant, notify, shutdown) = {
+        let mgr = manager.lock().await;
+        (
+          mgr.next_action_instant(),
+          mgr.state.notify.clone(),
+          mgr.state.shutdown_flag.clone(),
+        )
+      };
 
-            // Compute how long we should sleep           
-            let sleep_deadline = match next_instant {
-                Some(instant) => {
-                    let now = Instant::now();
-                    let max_sleep = Duration::from_secs(60); // wake periodically
-                    if instant <= now {
-                        now + Duration::from_millis(50)
-                    } else if instant - now > max_sleep {
-                        now + max_sleep
-                    } else {
-                        instant
-                    }
-                }
-                None => Instant::now() + Duration::from_secs(60),
-            };
-
-
-            tokio::select! {
-                _ = sleep_until(TokioInstant::from_std(sleep_deadline)) => {},
-                _ = notify.notified() => {
-                    // Woken up by external event (reset, AC change, playback)
-                    continue; // recalc immediately
-                }
-                _ = shutdown.notified() => {
-                    break; // exit loop cleanly
-                }
-            }
-
-            // Now check timeouts only once after wake
-            let mut mgr = manager.lock().await;
-            if !mgr.state.paused && !mgr.state.manually_paused {
-                mgr.check_timeouts().await;
-            }
+      // Compute how long we should sleep
+      let sleep_deadline = match next_instant {
+        Some(instant) => {
+          let now = Instant::now();
+          let max_sleep = Duration::from_secs(60); // wake periodically
+          if instant <= now {
+            now + Duration::from_millis(50)
+          } else if instant - now > max_sleep {
+            now + max_sleep
+          } else {
+            instant
+          }
         }
+        None => Instant::now() + Duration::from_secs(60),
+      };
 
-        log_message("Idle loop shutting down...");
-    })
+      tokio::select! {
+          _ = sleep_until(TokioInstant::from_std(sleep_deadline)) => {},
+          _ = notify.notified() => {
+              // Woken up by external event (reset, AC change, playback)
+              continue; // recalc immediately
+          }
+          _ = shutdown.notified() => {
+              break; // exit loop cleanly
+          }
+      }
+
+      // Now check timeouts only once after wake
+      let mut mgr = manager.lock().await;
+      if !mgr.state.paused && !mgr.state.manually_paused {
+        mgr.check_timeouts().await;
+      }
+    }
+
+    log_message("Idle loop shutting down...");
+  })
 }
 
 pub async fn spawn_lock_watcher(
-    manager: std::sync::Arc<tokio::sync::Mutex<crate::core::manager::Manager>>
+  manager: std::sync::Arc<tokio::sync::Mutex<crate::core::manager::Manager>>,
 ) -> tokio::task::JoinHandle<()> {
-    use std::time::Duration;
-    use tokio::time::sleep;
-    
-    tokio::spawn(async move {
-        loop {
-            let shutdown = {
-                let mgr = manager.lock().await;
-                mgr.state.shutdown_flag.clone()
-            };
+  use std::time::Duration;
+  use tokio::time::sleep;
 
-            // Wait until lock becomes active
-            {
-                let mut mgr = manager.lock().await;
-                while !mgr.state.lock_state.is_locked {
-                    let lock_notify = mgr.state.lock_notify.clone();
-                    drop(mgr);
-                    tokio::select! {
-                        _ = lock_notify.notified() => {},
-                        _ = shutdown.notified() => {
-                            log_message("Lock watcher shutting down...");
-                            return;
-                        }
-                    }
-                    mgr = manager.lock().await;
-                }
+  tokio::spawn(async move {
+    loop {
+      let shutdown = {
+        let mgr = manager.lock().await;
+        mgr.state.shutdown_flag.clone()
+      };
+
+      // Wait until lock becomes active
+      {
+        let mut mgr = manager.lock().await;
+        while !mgr.state.lock_state.is_locked {
+          let lock_notify = mgr.state.lock_notify.clone();
+          drop(mgr);
+          tokio::select! {
+              _ = lock_notify.notified() => {},
+              _ = shutdown.notified() => {
+                  log_message("Lock watcher shutting down...");
+                  return;
+              }
+          }
+          mgr = manager.lock().await;
+        }
+      }
+
+      log_message("Lock detected — entering lock watcher");
+
+      // Give the lock screen time to signal logind before first check
+      // This avoids race condition where we check before logind is updated
+      sleep(Duration::from_millis(500)).await;
+
+      // Monitor lock until it ends
+      loop {
+        let (process_info, maybe_cmd, was_locked, shutdown, lock_notify) = {
+          let mgr = manager.lock().await;
+          (
+            mgr.state.lock_state.process_info.clone(),
+            mgr.state.lock_state.command.clone(),
+            mgr.state.lock_state.is_locked,
+            mgr.state.shutdown_flag.clone(),
+            mgr.state.lock_notify.clone(),
+          )
+        };
+
+        if !was_locked {
+          break;
+        }
+
+        // Check if lock is still active using logind (primary) or process check (fallback)
+        let still_active = match is_session_locked_via_logind().await {
+          Some(locked) => {
+            // logind query succeeded - use its result as authoritative
+            locked
+          }
+          None => {
+            // logind unavailable - fall back to process checking
+            if let Some(ref info) = process_info {
+              is_process_active(info).await
+            } else if let Some(cmd) = maybe_cmd {
+              is_process_running(&cmd).await
+            } else {
+              sleep(Duration::from_millis(500)).await;
+              true
             }
+          }
+        };
 
-            log_message("Lock detected — entering lock watcher");
+        if !still_active {
+          let mut mgr = manager.lock().await;
 
-            // Monitor lock until it ends
-            loop {
-                let (process_info, maybe_cmd, was_locked, shutdown, lock_notify) = {
-                    let mgr = manager.lock().await;
-                    (
-                        mgr.state.lock_state.process_info.clone(),
-                        mgr.state.lock_state.command.clone(),
-                        mgr.state.lock_state.is_locked,
-                        mgr.state.shutdown_flag.clone(),
-                        mgr.state.lock_notify.clone(),
-                    )
-                };
+          if !mgr.state.lock_state.is_locked {
+            break;
+          }
 
-                if !was_locked {
-                    break;
-                }
+          // Fire resume command if configured
+          use crate::config::model::IdleAction;
+          if let Some(lock_action) = mgr
+            .state
+            .default_actions
+            .iter()
+            .chain(mgr.state.ac_actions.iter())
+            .chain(mgr.state.battery_actions.iter())
+            .find(|a| matches!(a.kind, IdleAction::LockScreen))
+          {
+            if let Some(resume_cmd) = &lock_action.resume_command {
+              log_message("Firing lockscreen resume command");
+              if let Err(e) = run_command_detached(resume_cmd).await {
+                log_message(&format!("Failed to run lock resume command: {}", e));
+              }
+            }
+          }
 
-                // Check if lock is still active
-                let still_active = if let Some(ref info) = process_info {
-                    is_process_active(info).await
-                } else if let Some(cmd) = maybe_cmd {
-                    is_process_running(&cmd).await
-                } else {
-                    sleep(Duration::from_millis(500)).await;
-                    true
-                };
+          mgr.state.lock_state.process_info = None;
+          mgr.state.lock_state.post_advanced = false;
+          mgr.state.action_index = 0;
+          mgr.state.lock_state.is_locked = false;
 
-                if !still_active {
-                    let mut mgr = manager.lock().await;
+          mgr.reset().await;
 
-                    if !mgr.state.lock_state.is_locked {
-                        break;
-                    }
+          log_message("Lockscreen ended — exiting lock watcher");
+          break;
+        }
 
-                    // Fire resume command if configured
-                    use crate::config::model::IdleAction;
-                    if let Some(lock_action) = mgr.state.default_actions.iter()
-                        .chain(mgr.state.ac_actions.iter())
-                        .chain(mgr.state.battery_actions.iter())
-                        .find(|a| matches!(a.kind, IdleAction::LockScreen))
-                    {
-                        if let Some(resume_cmd) = &lock_action.resume_command {
-                            log_message("Firing lockscreen resume command");
-                            if let Err(e) = run_command_detached(resume_cmd).await {
-                                log_message(&format!("Failed to run lock resume command: {}", e));
-                            }
-                        }
-                    }
-
-                    mgr.state.lock_state.process_info = None;
-                    mgr.state.lock_state.post_advanced = false;
-                    mgr.state.action_index = 0;
-                    mgr.state.lock_state.is_locked = false;
-
-                    mgr.reset().await;
-
-                    log_message("Lockscreen ended — exiting lock watcher");
-                    break;
-                }
-
-                tokio::select! {
-                    _ = lock_notify.notified() => {},
-                    _ = sleep(Duration::from_millis(500)) => {},
-                    _ = shutdown.notified() => {
-                        log_message("Lock watcher shutting down during active lock...");
-                        return;
-                    }
-                }
+        tokio::select! {
+            _ = lock_notify.notified() => {},
+            _ = sleep(Duration::from_millis(500)) => {},
+            _ = shutdown.notified() => {
+                log_message("Lock watcher shutting down during active lock...");
+                return;
             }
         }
-    })
+      }
+    }
+  })
 }
-


### PR DESCRIPTION
Extremely sorry that my editor formatted everything to 2 spaces instead of your default 4 :(

The original lock screen detection logic in `actions.rs` only checked if a lock screen process was running by looking for the process name using `pgrep`. This approach had a critical flaw (for my use-case):

It failed for nested lock commands like:
```
lock-screen:
  timeout 60
  command "qs -c noctalia-shell ipc call lockScreen lock"
end
```

In my case, `qs` (quickshell) is always running as a parent process, so the probe command would always detect it as running, even when the screen wasn't actually locked. This prevented proper lock screen state management.

The fix implements a dual-detection approach using BOTH systemd logind and process checking:

systemd logind DBus Interface (now the Primary Method)

Added `is_session_locked_via_logind()` function that queries the session lock state via:
```bash
busctl get-property --system -- org.freedesktop.login1 \
  /org/freedesktop/login1/session/auto \
  org.freedesktop.login1.Session \
  LockedHint
```

**Output:**
- `b true` - when locked
- `b false` - when not locked

This method is **universal** (theoretically) and works for:
- Nested lock commands (like the quickshell example)
- Standalone lockers (swaylock, hyprlock, etc.)
- Any lock mechanism that properly signals systemd logind

The existing `is_process_running()` check is retained as a fallback. This provides redundancy and compatibility with edge cases.

The only extra requirements for this to work are
- `busctl` command must be available (I think it's a part of systemd)
- System must support systemd logind (also I think most modern Linux systems do)
- Lock mechanism that properly signals systemd logind (Haven't found one that doesn't)

If the logind method proves to be truly universal, the process-based detection could potentially be removed entirely to simplify the code. However, keeping both methods provides maximum compatibility.

Another note, the logs were being spammed with `Process group empty, but found 'qs' by name` becuase the lock watcher
was still using the `pgrep` method, I updated that to be `logind` as well.
So that's a total of 2 files changed :)

That's it
Antariksh