### PR TITLE
feat(dbus): Add line about D-Bus inhibition to status/tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - On portal handle close edges, Stasis now applies a browser source-output guard before final inactive transitions.
   - This helps avoid mid-call inhibit drops when browser/portal close behavior is noisy.
 
+- **`stasis info` adds D-Bus inhibition info**
+  - Adds a line to the human-readable status/tooltip about the current state of D-Bus based inhibition.
+
 ### Notes
 
 - **Web Discord limitation (no mic attached)**

--- a/src/core/manager/info.rs
+++ b/src/core/manager/info.rs
@@ -71,6 +71,10 @@ fn render_status(state: &State, cfg_opt: Option<&Config>, now_ms: u64) -> String
     out.push_str(&format!("Paused: {}\n", yesno(state.paused())));
     out.push_str(&format!("Apps Inhibiting: {}\n", app));
     out.push_str(&format!("Media Players Playing: {}\n", media));
+    out.push_str(&format!(
+        "D-Bus Inhibiting: {}\n",
+        yesno(state.browser_activity_active(now_ms))
+    ));
 
     if let Some(cfg) = cfg_opt {
         if let Some(line) = next_step_line(cfg, state, now_ms) {
@@ -115,6 +119,10 @@ fn render_tooltip_compact(state: &State, cfg_opt: Option<&Config>, now_ms: u64) 
     t.push_str(&format!("Paused: {}\n", yesno(state.paused())));
     t.push_str(&format!("Apps Inhibiting: {}\n", app));
     t.push_str(&format!("Media Players Playing: {}\n", media));
+    t.push_str(&format!(
+        "D-Bus Inhibiting: {}\n",
+        yesno(state.browser_activity_active(now_ms))
+    ));
 
     if let Some(cfg) = cfg_opt {
         if let Some(line) = next_step_line(cfg, state, now_ms) {


### PR DESCRIPTION
This just allows the user to see in stasis info or the tooltip if idle is being inhibited via D-Dbus by some application.