### PR TITLE
Reset idle timer when compositor sends multiple CompositorIdled events without a CompositorResumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`stasis info` adds D-Bus inhibition info**
   - Adds a line to the human-readable status/tooltip about the current state of D-Bus based inhibition.
 
+### Fixes
+
+- **Reset idle timer when compositor sends multiple CompositorIdled events without a CompositorResumed**
+  - This fixes the behavior on niri where Stasis would just ignore keyboard and mouse activity and lock the screen anyway
+
 ### Notes
 
 - **Web Discord limitation (no mic attached)**

--- a/src/core/manager/engine.rs
+++ b/src/core/manager/engine.rs
@@ -354,12 +354,19 @@ impl Manager {
                     return Ok(out);
                 }
 
-                // We have entered true idle per compositor.
-                // This is the transition from "waiting for idle" -> "idle active".
-                if state.debounce_pending() && !state.paused() {
-                    state.set_debounce_pending(false);
+                if !state.paused() {
+                    // If debounce is already cleared, this Idled edge arrived without a
+                    // prior CompositorResumed. Some compositors (e.g. niri) do not send
+                    // CompositorResumed reliably. Treat the missing Resumed as implicit
+                    // activity so resume commands fire and the cycle resets before timing
+                    // the new idle window.
+                    if !state.debounce_pending() {
+                        self.handle_activity_like_event(state, &cfg, now_ms, &mut out);
+                    }
 
+                    // We have entered true idle per compositor.
                     // Start timing from *idle start*, not from last activity.
+                    state.set_debounce_pending(false);
                     state.set_step_base_ms(now_ms);
 
                     // Restart notify scheduling relative to this idle episode.

--- a/src/core/manager_tests.rs
+++ b/src/core/manager_tests.rs
@@ -276,6 +276,69 @@ fn no_notification_text_ignores_notify_seconds_before() {
 }
 
 #[test]
+fn compositor_idled_without_resumed_fires_resume_and_restarts_window() {
+    // Regression test for the niri workaround: when CompositorIdled arrives
+    // while debounce is already cleared (no CompositorResumed in between),
+    // stasis must (a) emit resume commands for any previously-fired step and
+    // (b) restart the idle window from the new Idled timestamp.
+
+    let mut s = step(PlanStepKind::Dpms, 5, "dpms_off");
+    s.resume_command = Some("dpms_on".to_string());
+
+    let mut mgr = Manager::new(cfg_with_plan(vec![s]));
+    let mut state = State::new(0);
+    state.set_plan_source(PlanSource::Desktop);
+
+    // First idle window: step fires at t=5000.
+    enter_idle(&mut mgr, &mut state, 0);
+    let actions = mgr
+        .handle_event(&mut state, Event::Tick { now_ms: 5000 })
+        .unwrap();
+    assert_eq!(
+        actions,
+        vec![Action::RunCommand {
+            command: "dpms_off".to_string()
+        }]
+    );
+    // debounce_pending is still false; no CompositorResumed arrives (niri scenario).
+
+    // Second CompositorIdled without any CompositorResumed in between.
+    let actions = mgr
+        .handle_event(&mut state, Event::CompositorIdled { now_ms: 10_000 })
+        .unwrap();
+
+    // (a) Resume command must fire for the previously-fired Dpms step.
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            Action::RunResumeCommand { command } if command == "dpms_on"
+        )),
+        "expected RunResumeCommand(dpms_on) in {actions:?}"
+    );
+
+    // (b) Idle window restarts from the new Idled timestamp.
+    assert_eq!(state.step_base_ms(), 10_000);
+    assert_eq!(state.step_index(), 0);
+
+    // Step must not fire before new_base + timeout.
+    let actions = mgr
+        .handle_event(&mut state, Event::Tick { now_ms: 14_999 })
+        .unwrap();
+    assert!(actions.is_empty());
+
+    // Step fires exactly at 10_000 + 5_000 = 15_000.
+    let actions = mgr
+        .handle_event(&mut state, Event::Tick { now_ms: 15_000 })
+        .unwrap();
+    assert_eq!(
+        actions,
+        vec![Action::RunCommand {
+            command: "dpms_off".to_string()
+        }]
+    );
+}
+
+#[test]
 fn browser_inhibit_stays_active_until_explicit_inactive_edge() {
     let plan = vec![step(PlanStepKind::Dpms, 1, "dpms")];
 


### PR DESCRIPTION
This fixes the behavior on niri where stasis would just ignore keyboard and mouse activity and lock the screen anyway