### PR TITLE
feat(#80): add PrepareSleep logind reaction

### DIFF
--- a/docs/man/stasis.5
+++ b/docs/man/stasis.5
@@ -95,6 +95,11 @@ List of patterns that inhibit idle behavior while active (case-insensitive).
 Regular expressions are allowed.
 
 .TP
+.B prepare_sleep_command \fICOMMAND\fR | ""
+Optional command run immediately when logind emits PrepareForSleep(true).
+This triggers when sleep is initiated externally (e.g., closing lid, systemctl suspend), not by stasis's idle plan.
+
+.TP
 .B lid_close_action \fICOMMAND\fR | ""
 Optional command run immediately when the laptop lid closes.
 Setting this to an empty string (\fB""\fR) clears any inherited lid-close action.

--- a/examples/stasis.rune
+++ b/examples/stasis.rune
@@ -24,6 +24,10 @@ default:
   ignore_remote_media true
   debounce_seconds 5
 
+  # Shell command to run immediately when logind emits PrepareForSleep(true).
+  # Unlike `pre_suspend_command`, this triggers when sleep is initiated externally.
+  # prepare_sleep_command "hyprlock"
+
   # Lid actions (optional, laptop only)
   #
   # Shell commands run immediately on lid close or open.

--- a/src/config/bootstrap.rs
+++ b/src/config/bootstrap.rs
@@ -112,6 +112,18 @@ default:
   ]
 
   # -----------------------------
+  # Prepare sleep command
+  # -----------------------------
+  # Shell command to run immediately when logind emits PrepareForSleep(true).
+  # Unlike `pre_suspend_command`, this triggers when sleep is initiated
+  # externally (e.g., closing lid, systemctl suspend), not by stasis idle plan.
+  #
+  # Examples:
+  #   prepare_sleep_command "swaylock -f"
+  # -----------------------------
+  #prepare_sleep_command ""
+
+  # -----------------------------
   # Lid actions (LAPTOP ONLY)
   #
   # Shell commands run immediately on lid close or open.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -137,6 +137,7 @@ fn parse_config_file(rc: &RuneConfig) -> Result<ConfigFile, String> {
 
             // scalars/lists under default
             cfg.pre_suspend_command = opt_nullable_string(rc, "default.pre_suspend_command")?;
+            cfg.prepare_sleep_command = opt_nullable_string(rc, "default.prepare_sleep_command")?;
 
             cfg.monitor_media = rc.get_or("default.monitor_media", false);
             cfg.ignore_remote_media = rc.get_or("default.ignore_remote_media", false);
@@ -225,6 +226,7 @@ fn parse_plan_block(
                 | "enable_loginctl"
                 | "enable_dbus_inhibit"
                 | "pre_suspend_command"
+                | "prepare_sleep_command"
                 | "monitor_media"
                 | "ignore_remote_media"
                 | "media_blacklist"
@@ -384,6 +386,7 @@ fn parse_profiles(rc: &RuneConfig) -> Result<Vec<Profile>, String> {
         pc.enable_loginctl = opt_bool(rc, format!("{name}.enable_loginctl"))?;
         pc.enable_dbus_inhibit = opt_bool(rc, format!("{name}.enable_dbus_inhibit"))?;
         pc.pre_suspend_command = opt_nullable_string2(rc, format!("{name}.pre_suspend_command"))?;
+        pc.prepare_sleep_command = opt_nullable_string2(rc, format!("{name}.prepare_sleep_command"))?;
 
         pc.monitor_media = opt_bool(rc, format!("{name}.monitor_media"))?;
         pc.ignore_remote_media = opt_bool(rc, format!("{name}.ignore_remote_media"))?;
@@ -619,6 +622,7 @@ fn log_config_debug(cfg_file: &ConfigFile) {
     eventline::debug!("  enable_loginctl = {:?}", cfg.enable_loginctl);
     eventline::debug!("  enable_dbus_inhibit = {:?}", cfg.enable_dbus_inhibit);
     eventline::debug!("  pre_suspend_command = {:?}", cfg.pre_suspend_command);
+    eventline::debug!("  prepare_sleep_command = {:?}", cfg.prepare_sleep_command);
 
     eventline::debug!("  lid_close_action = {:?}", cfg.lid_close_action);
     eventline::debug!("  lid_open_action  = {:?}", cfg.lid_open_action);

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -123,6 +123,7 @@ pub struct Config {
     pub enable_loginctl: bool,
     pub enable_dbus_inhibit: bool,
     pub pre_suspend_command: Option<String>,
+    pub prepare_sleep_command: Option<String>,
 
     /// Shell command to run immediately when the lid is closed (if any).
     pub lid_close_action: Option<String>,
@@ -172,6 +173,7 @@ impl Config {
             enable_loginctl: false,
             enable_dbus_inhibit: true,
             pre_suspend_command: None,
+            prepare_sleep_command: None,
 
             lid_close_action: None,
             lid_open_action: None,
@@ -334,6 +336,7 @@ pub struct PartialConfig {
     pub enable_loginctl: Option<bool>,
     pub enable_dbus_inhibit: Option<bool>,
     pub pre_suspend_command: Option<Option<String>>,
+    pub prepare_sleep_command: Option<Option<String>>,
 
     /// `None` = no override; `Some(None)` = clear; `Some(Some(cmd))` = set command.
     pub lid_close_action: Option<Option<String>>,
@@ -393,6 +396,9 @@ impl PartialConfig {
 
         if let Some(v) = &self.pre_suspend_command {
             base.pre_suspend_command = v.clone();
+        }
+        if let Some(v) = &self.prepare_sleep_command {
+            base.prepare_sleep_command = v.clone();
         }
 
         if let Some(v) = &self.lid_close_action {

--- a/src/core/manager/engine.rs
+++ b/src/core/manager/engine.rs
@@ -201,6 +201,13 @@ impl Manager {
             Event::PrepareForSleep { .. } => {
                 state.set_system_paused(true);
                 self.refresh_paused(state, now_ms);
+
+                if let Some(cmd) = &cfg.prepare_sleep_command {
+                    let c = cmd.trim().to_string();
+                    if !c.is_empty() {
+                        out.push(Action::RunCommand { command: c });
+                    }
+                }
             }
 
             Event::ResumedFromSleep { .. } => {


### PR DESCRIPTION
This PR add a new configuration param "prepare_sleep_command". It listens on the logind event "PrepareSleep" instead scheduled by the idle plan. That way you can add a command thats performend on every suspend also no covererd by the idle plan. 
Should close #80 