### PR TITLE
Make notify-send available to the service

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -27,6 +27,7 @@ let
   baseServicePathPkgs = with pkgs; [
     bashInteractive
     coreutils
+    libnotify
     systemd
     pulseaudio
   ];


### PR DESCRIPTION
I had to add `libnotify` to `extraPathPackages` to make it work, I think it should always be included in the path.